### PR TITLE
added the ability to select thumbnail derivative. Currently unstyled

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -80,6 +80,9 @@ SQL;
         if (Comparator::lessThan($oldVersion, '1.6.0-alpha')) {
             $conn->exec('ALTER TABLE faceted_browse_category ADD value_facet_mode VARCHAR(255) DEFAULT NULL AFTER helper_text_button_label');
         }
+        if (Comparator::lessThan($oldVersion, '1.9.0')) {
+            $conn->exec('ALTER TABLE faceted_browse_page ADD thumbnail_type VARCHAR(255) DEFAULT NULL AFTER resource_type');
+        }
     }
 
     public function attachListeners(SharedEventManagerInterface $sharedEventManager)

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "1.8.0"
+version = "1.9.0"
 omeka_version_constraint = "^4.0.0"
 name = "Faceted Browse"
 description = "Add faceted browsing to your sites"

--- a/src/Api/Adapter/FacetedBrowsePageAdapter.php
+++ b/src/Api/Adapter/FacetedBrowsePageAdapter.php
@@ -70,6 +70,11 @@ class FacetedBrowsePageAdapter extends AbstractEntityAdapter
         if ($this->shouldHydrate($request, 'o:title')) {
             $entity->setTitle($request->getValue('o:title'));
         }
+
+        if ($this->shouldHydrate($request, 'o-module-faceted_browse:thumbnail_type')) {
+            $entity->setThumbnailType($request->getValue('o-module-faceted_browse:thumbnail_type'));
+        }
+
         if ($this->shouldHydrate($request, 'o-module-faceted_browse:category')) {
             $categories = $request->getValue('o-module-faceted_browse:category');
             if (is_array($categories)) {

--- a/src/Api/Representation/FacetedBrowsePageRepresentation.php
+++ b/src/Api/Representation/FacetedBrowsePageRepresentation.php
@@ -21,7 +21,8 @@ class FacetedBrowsePageRepresentation extends AbstractEntityRepresentation
             'o:modified' => $modified ? $this->getDateTime($modified) : null,
             'o:title' => $this->title(),
             'o-module-faceted_browse:resource_type' => $this->resourceType(),
-        ];
+            'o-module-faceted_browse:thumbnail_type' => $this->thumbnailType(),
+            ];
     }
 
     public function adminUrl($action = null, $canonical = false)
@@ -77,5 +78,9 @@ class FacetedBrowsePageRepresentation extends AbstractEntityRepresentation
             $categories[] = $adapter->getRepresentation($categoryEntity);
         }
         return $categories;
+    }
+    public function thumbnailType()
+    {
+        return $this->resource->getThumbnailType();
     }
 }

--- a/src/ColumnType/Title.php
+++ b/src/ColumnType/Title.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace FacetedBrowse\ColumnType;
 
 use FacetedBrowse\Api\Representation\FacetedBrowseColumnRepresentation;
@@ -47,6 +48,12 @@ class Title implements ColumnTypeInterface
 
     public function renderContent(FacetedBrowseColumnRepresentation $column, AbstractResourceEntityRepresentation $resource): string
     {
-        return $resource->linkPretty('square');
+        // Get the thumbnail type from the page
+        $thumbnailType = $column->category()->page()->thumbnailType();
+
+        // Use the thumbnail type, or default to 'medium' if not set
+        $thumbnailType = $thumbnailType ?: 'square';
+
+        return $resource->linkPretty($thumbnailType);
     }
 }

--- a/src/Entity/FacetedBrowsePage.php
+++ b/src/Entity/FacetedBrowsePage.php
@@ -20,6 +20,11 @@ class FacetedBrowsePage extends AbstractEntity
         'item_sets' => 'Item sets', // @translate
         'media' => 'Media', // @translate
     ];
+    const THUMBNAIL_TYPES = [
+        'square' =>  'Square',
+        'medium' =>  'Medium',
+        'large' =>  'Large',
+    ];
 
     /**
      * @Id
@@ -89,6 +94,14 @@ class FacetedBrowsePage extends AbstractEntity
      */
     protected $resourceType;
 
+    /**
+     * @Column(
+     *     type="string",
+     *     length=255,
+     *     nullable=true
+     * )
+     */
+    protected $thumbnailType;
     /**
      * @OneToMany(
      *     targetEntity="FacetedBrowse\Entity\FacetedBrowseCategory",
@@ -174,7 +187,15 @@ class FacetedBrowsePage extends AbstractEntity
     {
         return $this->categories;
     }
+    public function setThumbnailType(?string $thumbnailType): void
+    {
+        $this->thumbnailType = $thumbnailType;
+    }
 
+    public function getThumbnailType(): ?string
+    {
+        return $this->thumbnailType;
+    }
     /**
      * @PrePersist
      */

--- a/src/Form/PageForm.php
+++ b/src/Form/PageForm.php
@@ -34,6 +34,8 @@ class PageForm extends Form
                     'value' => FacetedBrowsePage::RESOURCE_TYPES[$page->resourceType()],
                 ],
             ]);
+
+
         } else {
             $this->add([
                 'type' => LaminasElement\Select::class,
@@ -44,6 +46,17 @@ class PageForm extends Form
                     'value_options' => FacetedBrowsePage::RESOURCE_TYPES,
                 ],
             ]);
+
         }
+        $this -> add([
+            'type' => LaminasElement\Select::class,
+            'name' => 'o-module-faceted_browse:thumbnail_type',
+            'options' => [
+                'label' => 'Thumbnail type',
+                'info' => 'Select the thumbnail size for images on this page.',
+                'value_options' => FacetedBrowsePage::THUMBNAIL_TYPES,
+            ],
+
+        ]);
     }
 }

--- a/view/faceted-browse/site-admin/page/form.phtml
+++ b/view/faceted-browse/site-admin/page/form.phtml
@@ -42,6 +42,7 @@ $form->prepare();
 <fieldset>
     <?php echo $this->formRow($form->get('o:title')); ?>
     <?php echo $this->formRow($form->get($page ? 'resource_type' : 'o-module-faceted_browse:resource_type')); ?>
+    <?php echo $this->formRow($form->get($page ? 'o-module-faceted_browse:thumbnail_type' : 'o-module-faceted_browse:thumbnail_type')); ?>
 </fieldset>
 
 <?php if ($page): ?>


### PR DESCRIPTION
Our institution required the use of non-square thumbnail derivatives in our faceted browse page, due to some unsightly cropping of materials. I developed this fork to add that feature, and would like to contribute upstream if possible. There may be some styling issues to get this working on some themes; I'd like to work with the team to get this ready to merge in, if desired.