### PR TITLE
Keyboard a11y radios

### DIFF
--- a/asset/js/facet-render/item-set.js
+++ b/asset/js/facet-render/item-set.js
@@ -53,7 +53,7 @@ container.on('change', 'select.item-set', function(e) {
     handleUserInteraction($(this));
 });
 
-container.on('click', 'input.item-set', function(e) {
+container.on('change', 'input.item-set', function(e) {
     const thisValue = $(this);
     handleUserInteraction($(this));
     FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));

--- a/asset/js/facet-render/item-set.js
+++ b/asset/js/facet-render/item-set.js
@@ -55,6 +55,14 @@ container.on('change', 'select.item-set', function(e) {
 
 container.on('change', 'input.item-set', function(e) {
     const thisValue = $(this);
+    const facet = thisValue.closest('.facet');
+    const facetId = facet.data('facetId');
+    const dataValue = thisValue.data('value');
+
+    // Save focus state for restoration after page reload (only for radio buttons)
+    if (thisValue.attr('type') === 'radio') {
+        FacetedBrowse.setFocusState(facetId, `input.item-set[type="radio"][data-value="${dataValue}"]`);
+    }
     handleUserInteraction($(this));
     FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));
 });

--- a/asset/js/facet-render/item-set.js
+++ b/asset/js/facet-render/item-set.js
@@ -64,7 +64,7 @@ container.on('change', 'input.item-set', function(e) {
         FacetedBrowse.setFocusState(facetId, `input.item-set[type="radio"][data-value="${dataValue}"]`);
     }
     handleUserInteraction($(this));
-    FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));
+    FacetedBrowse.updateSelectList(thisValue.closest('.select-list'), false);
 });
 
 });

--- a/asset/js/facet-render/resource-class.js
+++ b/asset/js/facet-render/resource-class.js
@@ -53,7 +53,7 @@ container.on('change', 'select.resource-class', function(e) {
     handleUserInteraction($(this));
 });
 
-container.on('click', 'input.resource-class', function(e) {
+container.on('change', 'input.resource-class', function(e) {
     const thisValue = $(this);
     handleUserInteraction($(this));
     FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));

--- a/asset/js/facet-render/resource-class.js
+++ b/asset/js/facet-render/resource-class.js
@@ -64,7 +64,7 @@ container.on('change', 'input.resource-class', function(e) {
         FacetedBrowse.setFocusState(facetId, `input.resource-class[type="radio"][data-value="${dataValue}"]`);
     }
     handleUserInteraction($(this));
-    FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));
+    FacetedBrowse.updateSelectList(thisValue.closest('.select-list'), false);
 });
 
 });

--- a/asset/js/facet-render/resource-class.js
+++ b/asset/js/facet-render/resource-class.js
@@ -55,6 +55,14 @@ container.on('change', 'select.resource-class', function(e) {
 
 container.on('change', 'input.resource-class', function(e) {
     const thisValue = $(this);
+    const facet = thisValue.closest('.facet');
+    const facetId = facet.data('facetId');
+    const dataValue = thisValue.data('value');
+
+    // Save focus state for restoration after page reload (only for radio buttons)
+    if (thisValue.attr('type') === 'radio') {
+        FacetedBrowse.setFocusState(facetId, `input.resource-class[type="radio"][data-value="${dataValue}"]`);
+    }
     handleUserInteraction($(this));
     FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));
 });

--- a/asset/js/facet-render/resource-template.js
+++ b/asset/js/facet-render/resource-template.js
@@ -54,7 +54,7 @@ container.on('change', 'select.resource-template', function(e) {
     handleUserInteraction($(this));
 });
 
-container.on('click', 'input.resource-template', function(e) {
+container.on('change', 'input.resource-template', function(e) {
     const thisValue = $(this);
     handleUserInteraction($(this));
     FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));

--- a/asset/js/facet-render/resource-template.js
+++ b/asset/js/facet-render/resource-template.js
@@ -65,7 +65,7 @@ container.on('change', 'input.resource-template', function(e) {
         FacetedBrowse.setFocusState(facetId, `input.resource-template[type="radio"][data-value="${dataValue}"]`);
     }
     handleUserInteraction($(this));
-    FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));
+    FacetedBrowse.updateSelectList(thisValue.closest('.select-list'), false);
 });
 
 

--- a/asset/js/facet-render/resource-template.js
+++ b/asset/js/facet-render/resource-template.js
@@ -56,6 +56,14 @@ container.on('change', 'select.resource-template', function(e) {
 
 container.on('change', 'input.resource-template', function(e) {
     const thisValue = $(this);
+    const facet = thisValue.closest('.facet');
+    const facetId = facet.data('facetId');
+    const dataValue = thisValue.data('value');
+
+    // Save focus state for restoration after page reload (only for radio buttons)
+    if (thisValue.attr('type') === 'radio') {
+        FacetedBrowse.setFocusState(facetId, `input.resource-template[type="radio"][data-value="${dataValue}"]`);
+    }
     handleUserInteraction($(this));
     FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));
 });

--- a/asset/js/facet-render/value.js
+++ b/asset/js/facet-render/value.js
@@ -90,7 +90,7 @@ container.on('change', 'select.value', function(e) {
 });
 
 // Handle single_list interaction.
-container.on('click', 'input.value[type="radio"]', function(e) {
+container.on('change', 'input.value[type="radio"]', function(e) {
     const thisValue = $(this);
     handleUserInteraction(thisValue);
     FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));

--- a/asset/js/facet-render/value.js
+++ b/asset/js/facet-render/value.js
@@ -92,6 +92,12 @@ container.on('change', 'select.value', function(e) {
 // Handle single_list interaction.
 container.on('change', 'input.value[type="radio"]', function(e) {
     const thisValue = $(this);
+    const facet = thisValue.closest('.facet');
+    const facetId = facet.data('facetId');
+    const dataValue = thisValue.data('value');
+
+    // Save focus state for restoration after page reload
+    FacetedBrowse.setFocusState(facetId, `input.value[type="radio"][data-value="${dataValue}"]`);
     handleUserInteraction(thisValue);
     FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));
 });

--- a/asset/js/facet-render/value.js
+++ b/asset/js/facet-render/value.js
@@ -99,14 +99,14 @@ container.on('change', 'input.value[type="radio"]', function(e) {
     // Save focus state for restoration after page reload
     FacetedBrowse.setFocusState(facetId, `input.value[type="radio"][data-value="${dataValue}"]`);
     handleUserInteraction(thisValue);
-    FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));
+    FacetedBrowse.updateSelectList(thisValue.closest('.select-list'), false);
 });
 
 // Handle multiple_list interaction.
 container.on('click', 'input.value[type="checkbox"]', function(e) {
     const thisValue = $(this);
     handleUserInteraction(thisValue);
-    FacetedBrowse.updateSelectList(thisValue.closest('.select-list'));
+    FacetedBrowse.updateSelectList(thisValue.closest('.select-list'), false);
 });
 
 // Handle text_input interaction.

--- a/asset/js/faceted-browse.js
+++ b/asset/js/faceted-browse.js
@@ -293,43 +293,65 @@ const FacetedBrowse = {
         return history.state.hasOwnProperty(stateName) ? history.state[stateName] : undefined;
     },
 
-    updateSelectList: selectList => {
+    updateSelectList: (selectList, reorder = true) => {
         const facet = selectList.closest('.facet');
         const truncateListItems = selectList.data('truncateListItems');
-        // First, sort the selected list items and prepend them to the list.
-        const listItemsSelected = selectList.find('input.selected')
-            .closest('.select-list-item')
-            .show()
-            .sort(function(a, b) {
-                // Subtracting seems to be cross-browser compatible.
-                return $(a).data('index') - $(b).data('index');
-            });
-        listItemsSelected.prependTo(selectList);
-        // Then, sort the unselected list items and append them to the list.
-        const listItemsUnselected = selectList.find('input:not(.selected)')
-            .closest('.select-list-item')
-            .show()
-            .sort(function(a, b) {
-                // Subtracting seems to be cross-browser compatible.
-                return $(a).data('index') - $(b).data('index');
-            });
-        listItemsUnselected.appendTo(selectList);
+        let listItemsSelected, listItemsUnselected;
+        
+        if (reorder) {
+            // First, sort the selected list items and prepend them to the list.
+            listItemsSelected = selectList.find('input.selected')
+                .closest('.select-list-item')
+                .show()
+                .sort(function(a, b) {
+                    // Subtracting seems to be cross-browser compatible.
+                    return $(a).data('index') - $(b).data('index');
+                });
+            listItemsSelected.prependTo(selectList);
+            // Then, sort the unselected list items and append them to the list.
+            listItemsUnselected = selectList.find('input:not(.selected)')
+                .closest('.select-list-item')
+                .show()
+                .sort(function(a, b) {
+                    // Subtracting seems to be cross-browser compatible.
+                    return $(a).data('index') - $(b).data('index');
+                });
+            listItemsUnselected.appendTo(selectList);
+        }
+        
         const listItems = selectList.find('.select-list-item');
         if (!truncateListItems || truncateListItems >= listItems.length) {
             // No need to show expand when list does not surpass configured limit.
+            if (!reorder) {
+                // Show all items when no truncation is needed and no reordering happened
+                listItems.show();
+            }
+            // Items were already shown during reordering if reorder=true
+            facet.find('.select-list-expand').hide();
+            facet.find('.select-list-collapse').hide();
             return;
         }
         if (selectList.hasClass('expanded')) {
             // No need to hide items when list is expanded.
+            listItems.show();
             facet.find('.select-list-expand').hide();
             facet.find('.select-list-collapse').show();
             return;
         }
+        
+        // Get selected/unselected items if not already retrieved during reordering
+        if (!reorder) {
+            listItemsSelected = selectList.find('input.selected').closest('.select-list-item');
+            listItemsUnselected = selectList.find('input:not(.selected)').closest('.select-list-item');
+        }
+        
         if (truncateListItems < listItemsSelected.length) {
             // Show all selected items even if they surpass the configured limit.
+            listItemsSelected.show();
             listItemsUnselected.hide();
         } else {
             // Truncate to the configured limit.
+            listItems.slice(0, truncateListItems).show();
             listItems.slice(truncateListItems).hide();
         }
         const hiddenCount = listItems.filter(':hidden').length;

--- a/asset/js/faceted-browse.js
+++ b/asset/js/faceted-browse.js
@@ -101,6 +101,34 @@ const FacetedBrowse = {
         FacetedBrowse.replaceHistoryState();
     },
     /**
+     * Set the focus state to restore focus after content reload.
+     *
+     * @param int facetId The facet ID
+     * @param string selector CSS selector to identify the element to focus
+     */
+    setFocusState: (facetId, selector) => {
+        FacetedBrowse.state.lastFocusedFacetId = facetId;
+        FacetedBrowse.state.lastFocusedSelector = selector;
+        FacetedBrowse.replaceHistoryState();
+    },
+    /**
+     * Restore focus to the last interacted element if applicable.
+     */
+    restoreFocus: () => {
+        if (FacetedBrowse.state.lastFocusedFacetId && FacetedBrowse.state.lastFocusedSelector) {
+            const facet = $(`.facet[data-facet-id="${FacetedBrowse.state.lastFocusedFacetId}"]`);
+            if (facet.length) {
+                const element = facet.find(FacetedBrowse.state.lastFocusedSelector);
+                if (element.length) {
+                    // Use setTimeout to ensure the DOM is fully updated
+                    setTimeout(() => {
+                        element.focus();
+                    }, 100);
+                }
+            }
+        }
+    },
+    /**
      * Set the sorting state.
      *
      * @param string sortBy
@@ -246,6 +274,8 @@ const FacetedBrowse = {
         FacetedBrowse.state.page = null;
         FacetedBrowse.state.facetStates = {};
         FacetedBrowse.state.facetQueries = {};
+        FacetedBrowse.state.lastFocusedFacetId = null;
+        FacetedBrowse.state.lastFocusedSelector = null;
         FacetedBrowse.replaceHistoryState();
     },
     /**

--- a/asset/js/site/page.js
+++ b/asset/js/site/page.js
@@ -125,6 +125,8 @@ FacetedBrowse.setStateChangeHandler(function(facetsQuery, sortBy, sortOrder, pag
     $.get(`${urlBrowse}?${queries.join('&')}`).done(function(html) {
         sectionContent.html(html).removeClass('loading');
         setPermalinkFragment();
+        // Restore focus to the last interacted element
+        FacetedBrowse.restoreFocus();
     }).fail(failBrowse);
 });
 


### PR DESCRIPTION
**Updated**
## Issue
This work revealed and addressed several accessibility related issues:

- Handlers were not listening to keyboard input, meaning that keyboard users were not able to move through te list options
- When that was addressed, users could enter the list area, but focus was lost upon making a selection. For radios, this meant leaving the options list entirely. 
- When that was addressed, when a selection was made focus remained in the options list, but because the list was reordered, the focused moved to the top of the list. For radios, this meant it was never possible to explore past the second item of the list. For checkbox, this meant starting over each time you made a selection. 
- Even with the focus being restored to appropriate place, silent reordering of the list poses accessibility concerns.

## The Fix
Three changes were introduced:

- List handlers now listen for change so they respond to keyboard input and allow navigation into the list options
- Upon selection and reload, focus is restored to where the user had been in the list
- Reordering upon user interaction is disabled
- Reordering still happens during other events where appropriate (e.g., permalinks will have the selected options at the top of the options list).

