### PR TITLE
Convert filters sidebar to dialog at mobile breakpoint

### DIFF
--- a/asset/css/site/page.css
+++ b/asset/css/site/page.css
@@ -186,6 +186,9 @@ input[type="text"].permalink {
     top: 1rem;
     right: 1rem;
     font-size: 1rem;
+    color: #000;
+    min-width: 24px;
+    min-height: 24px;
 }
 
 .close-glyph:before {

--- a/asset/css/site/page.css
+++ b/asset/css/site/page.css
@@ -239,6 +239,11 @@ input[type="text"].permalink {
 }
 
 @media print, screen and (max-width: 39.9988em) {
+    #section-sidebar,
+    #section-content {
+        padding: 0;
+    }
+
     #section-sidebar-modal-toggle,
     #section-sidebar-modal-close {
         display: block;

--- a/asset/css/site/page.css
+++ b/asset/css/site/page.css
@@ -35,6 +35,11 @@
     margin: 0 .5rem 0 0;
 }
 
+#facets,
+#categories {
+    width: 100%;
+}
+
 #categories,
 .facet ul {
     list-style: none;

--- a/asset/css/site/page.css
+++ b/asset/css/site/page.css
@@ -180,14 +180,6 @@ input[type="text"].permalink {
     overflow: scroll;
 }
 
-
-@media print, screen and (min-width: 40em) {
-    #section-sidebar-modal-toggle,
-    #section-sidebar-modal-close {
-        display: none !important;
-    }
-}
-
 #section-sidebar button.close-button {
     background-color: transparent;
     position: absolute;
@@ -232,7 +224,17 @@ input[type="text"].permalink {
     margin-bottom: 0;
 }
 
+#section-sidebar-modal-toggle,
+#section-sidebar-modal-close {
+    display: none;
+}
+
 @media print, screen and (max-width: 39.9988em) {
+    #section-sidebar-modal-toggle,
+    #section-sidebar-modal-close {
+        display: block;
+    }
+
     .faceted-browse-page #container {
         flex-wrap: wrap;
         max-width: 100%;
@@ -247,7 +249,6 @@ input[type="text"].permalink {
         display: none;
     }
 
-
     .faceted-browse-page dialog #section-sidebar {
         display: block;
         position: fixed;
@@ -257,7 +258,7 @@ input[type="text"].permalink {
         bottom: 0;
         padding: 1rem;
         background-color: #fff;
-        z-index: 999;
+        overflow: auto;
     }
 
     .faceted-browse-page .tablesaw td {

--- a/asset/css/site/page.css
+++ b/asset/css/site/page.css
@@ -185,6 +185,7 @@ input[type="text"].permalink {
     position: absolute;
     top: 1rem;
     right: 1rem;
+    font-size: 1rem;
 }
 
 .close-glyph:before {

--- a/asset/css/site/page.css
+++ b/asset/css/site/page.css
@@ -248,7 +248,7 @@ input[type="text"].permalink {
     }
 
 
-    .faceted-browse-page #section-sidebar.open {
+    .faceted-browse-page dialog #section-sidebar {
         display: block;
         position: fixed;
         top: 0;

--- a/asset/js/site/page.js
+++ b/asset/js/site/page.js
@@ -22,10 +22,11 @@ const mediaQuery = window.matchMedia('(min-width: 896px)');
 // Reset modal attributes for desktop widths.
 const handleTabletChange = function(e) {
     modalToggleButton.attr('aria-expanded', 'false');
-    sectionContent.attr('aria-hidden', 'true').removeClass('open');
+    sectionContent.attr('aria-hidden', 'true');
     if (e.matches) {
         sectionSidebar.attr('aria-hidden', 'false');
         modalToggleButton.attr('aria-expanded', 'false');
+        sectionContent.attr('aria-hidden', 'false');
     }
 };
 
@@ -38,9 +39,11 @@ const enableModal = function() {
         if (modalToggleButton.attr('aria-expanded') == 'true') {
             modalToggleButton.attr('aria-expanded', 'false');
             sectionSidebar.attr('aria-hidden', 'true');
+            sectionContent.attr('aria-hidden', 'false');
         } else {
             modalToggleButton.attr('aria-expanded', 'true');
             sectionSidebar.attr('aria-hidden', 'false');
+            sectionContent.attr('aria-hidden', 'true');
         }
         sectionSidebar.trigger('toggle');
     });

--- a/asset/js/site/page.js
+++ b/asset/js/site/page.js
@@ -1,4 +1,4 @@
-$(document).ready(function () {
+$(document).ready(function() {
 
 const container = $('#container');
 const sectionSidebar = $('#section-sidebar');
@@ -20,7 +20,7 @@ const failCategory = data => sectionContent.html(`${Omeka.jsTranslate('Error fet
 const mediaQuery = window.matchMedia('(max-width: 39.9988em)');
 
 // Reset modal attributes for desktop widths.
-const handleTabletChange = function (e) {
+const handleTabletChange = function(e) {
     if (e.matches) {
         const dialogWrapper = $('<dialog id="section-sidebar-dialog" aria-label="Mobile dialog" aria-labelledby="section-sidebar-dialog section-sidebar"></dialog>');
         sectionSidebar.wrap(dialogWrapper);
@@ -31,8 +31,8 @@ const handleTabletChange = function (e) {
 };
 
 // Implements modal behavior for facet sidebar on mobile widths.
-const enableModal = function () {
-    container.on('click', '#section-sidebar-modal-toggle', function () {
+const enableModal = function() {
+    container.on('click', '#section-sidebar-modal-toggle', function() {
         const activeDialog = document.getElementById('section-sidebar-dialog');
         modalToggleButton.attr('aria-expanded', 'true');
         activeDialog.showModal();
@@ -42,12 +42,12 @@ const enableModal = function () {
         });
     });
 
-    container.on('click', '#section-sidebar .close-button', function () {
+    container.on('click', '#section-sidebar .close-button', function() {
         closeModal();
     });
 };
 
-const closeModal = function () {
+const closeModal = function() {
     const activeModal = document.getElementById('section-sidebar-dialog');
     if (activeModal) {
         activeModal.close();
@@ -60,8 +60,8 @@ const showClipboardCopySuccessful = () => {
     // Indicate successful copy here
     $('.permalink .success').addClass('active').show();
     $('.permalink .default').addClass('inactive');
-    setTimeout(function () {
-        $('.permalink .success').fadeOut(1000, function () {
+    setTimeout(function() {
+        $('.permalink .success').fadeOut(1000, function() {
             $(this).removeClass('active');
             $('.permalink .default').removeClass('inactive');
         });
@@ -69,10 +69,10 @@ const showClipboardCopySuccessful = () => {
 };
 
 /**
-    * Apply a previous state to the page.
-    */
-const applyPreviousState = function () {
-    $('.facet').each(function () {
+ * Apply a previous state to the page.
+ */
+const applyPreviousState = function() {
+    $('.facet').each(function() {
         const thisFacet = $(this);
         FacetedBrowse.handleFacetApplyState(thisFacet.data('facetType'), thisFacet.data('facetId'), this);
     });
@@ -80,21 +80,21 @@ const applyPreviousState = function () {
 };
 
 /**
-    * Set the permalink fragment.
-    */
-const setPermalinkFragment = function () {
+ * Set the permalink fragment.
+ */
+const setPermalinkFragment = function() {
     const fragment = encodeURIComponent(JSON.stringify(FacetedBrowse.state))
     $('.permalink').data('fragment', fragment);
 };
 
 /**
-    * Render the categories of this page.
-    */
-const renderCategories = function () {
-    $.get(urlCategories).done(function (html) {
+ * Render the categories of this page.
+ */
+const renderCategories = function() {
+    $.get(urlCategories).done(function(html) {
         sectionSidebar.html(html);
         $('.categories-container').find('a,input,button,select').first().focus();
-        $.get(urlBrowse).done(function (html) {
+        $.get(urlBrowse).done(function(html) {
             sectionContent.html(html);
             setPermalinkFragment();
         }).fail(failBrowse);
@@ -105,7 +105,7 @@ const renderCategories = function () {
 FacetedBrowse.initState();
 
 // Then, set the state change handler.
-FacetedBrowse.setStateChangeHandler(function (facetsQuery, sortBy, sortOrder, page) {
+FacetedBrowse.setStateChangeHandler(function(facetsQuery, sortBy, sortOrder, page) {
     const facets = $('#facets');
     const queries = [];
 
@@ -116,7 +116,7 @@ FacetedBrowse.setStateChangeHandler(function (facetsQuery, sortBy, sortOrder, pa
     if (null !== page) queries.push(`page=${page}`);
     queries.push(`faceted_browse_category_id=${facets.data('categoryId')}`);
     sectionContent.text(Omeka.jsTranslate('Loading results…')).addClass('loading');
-    $.get(`${urlBrowse}?${queries.join('&')}`).done(function (html) {
+    $.get(`${urlBrowse}?${queries.join('&')}`).done(function(html) {
         sectionContent.html(html).removeClass('loading');
         setPermalinkFragment();
     }).fail(failBrowse);
@@ -125,13 +125,13 @@ FacetedBrowse.setStateChangeHandler(function (facetsQuery, sortBy, sortOrder, pa
 // Then, set up the page for first load.
 if (FacetedBrowse.getState('categoryId')) {
     // This page has a previously saved category state.
-    $.get(urlFacets, { category_id: FacetedBrowse.getState('categoryId') }).done(function (html) {
+    $.get(urlFacets, {category_id: FacetedBrowse.getState('categoryId')}).done(function(html) {
         sectionSidebar.html(html);
         applyPreviousState();
     }).fail(failFacet);
 } else if (container.data('categoryId')) {
     // There is one category. Skip categories list and show facets list.
-    $.get(urlFacets, { category_id: container.data('categoryId') }).done(function (html) {
+    $.get(urlFacets, {category_id: container.data('categoryId')}).done(function(html) {
         sectionSidebar.html(html);
         applyPreviousState();
         $('#categories-return').hide();
@@ -142,20 +142,20 @@ if (FacetedBrowse.getState('categoryId')) {
 }
 
 // Handle category click.
-container.on('click', '.category', function (e) {
+container.on('click', '.category', function(e) {
     e.preventDefault();
     const thisCategory = $(this);
     FacetedBrowse.resetState(thisCategory.data('categoryId'));
-    $.get(urlFacets, { category_id: thisCategory.data('categoryId') }).done(function (html) {
+    $.get(urlFacets, {category_id: thisCategory.data('categoryId')}).done(function(html) {
         sectionSidebar.html(html);
-        sectionSidebar.find('.select-list').each(function () {
+        sectionSidebar.find('.select-list').each(function() {
             // Must update the select lists so they are truncated.
             FacetedBrowse.updateSelectList($(this));
         });
         $('.facets-container').find('a,input,button,select').first().focus();
         const queries = [];
         queries.push(`faceted_browse_category_id=${thisCategory.data('categoryId')}`);
-        $.get(`${urlBrowse}?${queries.join('&')}`).done(function (html) {
+        $.get(`${urlBrowse}?${queries.join('&')}`).done(function(html) {
             sectionContent.html(html);
             setPermalinkFragment();
         }).fail(failBrowse);
@@ -163,71 +163,71 @@ container.on('click', '.category', function (e) {
 });
 
 // Handle a categories return click.
-container.on('click', '#categories-return', function (e) {
+container.on('click', '#categories-return', function(e) {
     FacetedBrowse.resetState();
     renderCategories();
 });
 
 // Handle pagination next button.
-container.on('click', '.next', function (e) {
+container.on('click', '.next', function(e) {
     e.preventDefault();
     const thisButton = $(this);
     const form = thisButton.prevAll('form');
     if (!thisButton.hasClass('inactive')) {
         FacetedBrowse.setPaginationState(parseInt(form.find('input[name="page"]').val()) + 1);
-        $.get(thisButton.prop('href'), function (html) {
+        $.get(thisButton.prop('href'), function(html) {
             sectionContent.html(html);
         });
     }
 });
 
 // Handle pagination previous button.
-container.on('click', '.previous', function (e) {
+container.on('click', '.previous', function(e) {
     e.preventDefault();
     const thisButton = $(this);
     const form = thisButton.prevAll('form');
     if (!thisButton.hasClass('inactive')) {
         FacetedBrowse.setPaginationState(parseInt(form.find('input[name="page"]').val()) - 1);
-        $.get(thisButton.prop('href'), function (html) {
+        $.get(thisButton.prop('href'), function(html) {
             sectionContent.html(html);
         });
     }
 });
 
 // Handle pagination form.
-container.on('submit', '.pagination form', function (e) {
+container.on('submit', '.pagination form', function(e) {
     e.preventDefault();
     const thisForm = $(this);
     FacetedBrowse.setPaginationState(thisForm.find('input[name="page"]').val());
-    $.get(`${urlBrowse}?${$(this).serialize()}`, {}, function (html) {
+    $.get(`${urlBrowse}?${$(this).serialize()}`, {}, function(html) {
         sectionContent.html(html);
         setPermalinkFragment();
     });
 });
 
 // Handle sort form.
-container.on('submit', 'form.sorting', function (e) {
+container.on('submit', 'form.sorting', function(e) {
     e.preventDefault();
     const thisForm = $(this);
     FacetedBrowse.setSortingState(
         thisForm.find('select[name="sort_by"]').val(),
         thisForm.find('select[name="sort_order"]').val()
     );
-    $.get(`${urlBrowse}?${$(this).serialize()}`, {}, function (html) {
+    $.get(`${urlBrowse}?${$(this).serialize()}`, {}, function(html) {
         sectionContent.html(html);
         setPermalinkFragment();
     });
 });
 
 // Handle permalink button (copy to clipboard button).
-container.on('click', '.permalink', function (e) {
+container.on('click', '.permalink', function(e) {
     e.preventDefault();
     const thisButton = $(this);
     const permalink = `${thisButton.data('url')}#${thisButton.data('fragment')}`;
 
     if (navigator.clipboard && window.isSecureContext) {
         // Use the browser's clipboard API if possible.
-        navigator.clipboard.writeText(permalink).then(function () {
+        navigator.clipboard.writeText(permalink).then(function() {
             showClipboardCopySuccessful();
         });
     } else {

--- a/asset/js/site/page.js
+++ b/asset/js/site/page.js
@@ -1,239 +1,241 @@
-$(document).ready(function() {
+$(document).ready(function () {
 
-const container = $('#container');
-const sectionSidebar = $('#section-sidebar');
-const sectionContent = $('#section-content');
+    const container = $('#container');
+    const sectionSidebar = $('#section-sidebar');
+    const sectionContent = $('#section-content');
 
-const urlCategories = container.data('urlCategories');
-const urlFacets = container.data('urlFacets');
-const urlBrowse = container.data('urlBrowse');
+    const urlCategories = container.data('urlCategories');
+    const urlFacets = container.data('urlFacets');
+    const urlBrowse = container.data('urlBrowse');
 
-const modalToggleButton = $("#section-sidebar-modal-toggle");
-const modalCloseButton = $('#section-sidebar-modal-close');
+    const modalToggleButton = $("#section-sidebar-modal-toggle");
+    const modalCloseButton = $('#section-sidebar-modal-close');
 
-// Callbacks that handle  request errors.
-const failBrowse = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching browse markup.')} ${data.status} (${data.statusText})`);
-const failFacet = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching facet markup.')} ${data.status} (${data.statusText})`);
-const failCategory = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching category markup.')} ${data.status} (${data.statusText})`);
+    // Callbacks that handle  request errors.
+    const failBrowse = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching browse markup.')} ${data.status} (${data.statusText})`);
+    const failFacet = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching facet markup.')} ${data.status} (${data.statusText})`);
+    const failCategory = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching category markup.')} ${data.status} (${data.statusText})`);
 
-// Set breakpoint for using facet modal window.
-const mediaQuery = window.matchMedia('(min-width: 896px)');
+    // Set breakpoint for using facet modal window.
+    const mediaQuery = window.matchMedia('(min-width: 896px)');
 
-// Reset modal attributes for desktop widths.
-const handleTabletChange = function(e) {
-    if (e.matches) {
-        closeModal();
-        sectionSidebar.unwrap();
-    } else {
-        const dialogWrapper = $('<dialog id="section-sidebar-dialog" aria-label="Mobile dialog" aria-labelledby="section-sidebar-dialog section-sidebar"></dialog>');
-        sectionSidebar.wrap(dialogWrapper);
-    }
-};
+    // Reset modal attributes for desktop widths.
+    const handleTabletChange = function (e) {
+        if (e.matches) {
+            closeModal();
+            sectionSidebar.unwrap();
+        } else {
+            const dialogWrapper = $('<dialog id="section-sidebar-dialog" aria-label="Mobile dialog" aria-labelledby="section-sidebar-dialog section-sidebar"></dialog>');
+            sectionSidebar.wrap(dialogWrapper);
+        }
+    };
 
-// Implements modal behavior for facet sidebar on mobile widths.
-const enableModal = function() {
-    container.on('click', '#section-sidebar-modal-toggle', function() {
+    // Implements modal behavior for facet sidebar on mobile widths.
+    const enableModal = function () {
+        container.on('click', '#section-sidebar-modal-toggle', function () {
+            modalToggleButton.attr('aria-expanded', 'false');
+            document.getElementById('section-sidebar-dialog').showModal();
+            sectionSidebar.find('button').first().focus();
+        });
+
+        container.on('click', '#section-sidebar .close-button', function () {
+            closeModal();
+        });
+    };
+
+    const closeModal = function () {
+        document.getElementById('section-sidebar-dialog').close();
         modalToggleButton.attr('aria-expanded', 'false');
-        document.getElementById('section-sidebar-dialog').showModal();
-    });
+    }
 
-    container.on('click', '#section-sidebar .close-button', function() {
-        closeModal();
-    });
-};
+    // Show that a copy to clipboard was successful.
+    const showClipboardCopySuccessful = () => {
+        // Indicate successful copy here
+        $('.permalink .success').addClass('active').show();
+        $('.permalink .default').addClass('inactive');
+        setTimeout(function () {
+            $('.permalink .success').fadeOut(1000, function () {
+                $(this).removeClass('active');
+                $('.permalink .default').removeClass('inactive');
+            });
+        }, 1500);
+    };
 
-const closeModal = function() {
-    document.getElementById('section-sidebar-dialog').close();
-    modalToggleButton.attr('aria-expanded', 'false');
-}
-
-// Show that a copy to clipboard was successful.
-const showClipboardCopySuccessful = () => {
-    // Indicate successful copy here
-    $('.permalink .success').addClass('active').show();
-    $('.permalink .default').addClass('inactive');
-    setTimeout(function() {
-        $('.permalink .success').fadeOut(1000, function() {
-            $(this).removeClass('active');
-            $('.permalink .default').removeClass('inactive');
+    /**
+     * Apply a previous state to the page.
+     */
+    const applyPreviousState = function () {
+        $('.facet').each(function () {
+            const thisFacet = $(this);
+            FacetedBrowse.handleFacetApplyState(thisFacet.data('facetType'), thisFacet.data('facetId'), this);
         });
-    }, 1500);
-};
+        FacetedBrowse.triggerStateChange();
+    };
 
-/**
- * Apply a previous state to the page.
- */
-const applyPreviousState = function() {
-    $('.facet').each(function() {
-        const thisFacet = $(this);
-        FacetedBrowse.handleFacetApplyState(thisFacet.data('facetType'), thisFacet.data('facetId'), this);
-    });
-    FacetedBrowse.triggerStateChange();
-};
+    /**
+     * Set the permalink fragment.
+     */
+    const setPermalinkFragment = function () {
+        const fragment = encodeURIComponent(JSON.stringify(FacetedBrowse.state))
+        $('.permalink').data('fragment', fragment);
+    };
 
-/**
- * Set the permalink fragment.
- */
-const setPermalinkFragment = function() {
-    const fragment = encodeURIComponent(JSON.stringify(FacetedBrowse.state))
-    $('.permalink').data('fragment', fragment);
-};
+    /**
+     * Render the categories of this page.
+     */
+    const renderCategories = function () {
+        $.get(urlCategories).done(function (html) {
+            sectionSidebar.html(html);
+            $('.categories-container').find('a,input,button,select').first().focus();
+            $.get(urlBrowse).done(function (html) {
+                sectionContent.html(html);
+                setPermalinkFragment();
+            }).fail(failBrowse);
+        }).fail(failCategory);
+    };
 
-/**
- * Render the categories of this page.
- */
-const renderCategories = function() {
-    $.get(urlCategories).done(function(html) {
-        sectionSidebar.html(html);
-        $.get(urlBrowse).done(function(html) {
-            sectionContent.html(html);
-            setPermalinkFragment();
-        }).fail(failBrowse);
-    }).fail(failCategory);
-};
+    // First, initialize the state.
+    FacetedBrowse.initState();
 
-// First, initialize the state.
-FacetedBrowse.initState();
-
-// Then, set the state change handler.
-FacetedBrowse.setStateChangeHandler(function(facetsQuery, sortBy, sortOrder, page) {
-    const facets = $('#facets');
-    const queries = [];
-
-    // Add facets, sorting, and pagination queries.
-    queries.push(facetsQuery);
-    if (null !== sortBy) queries.push(`sort_by=${sortBy}`);
-    if (null !== sortOrder) queries.push(`sort_order=${sortOrder}`);
-    if (null !== page) queries.push(`page=${page}`);
-    queries.push(`faceted_browse_category_id=${facets.data('categoryId')}`);
-    sectionContent.text(Omeka.jsTranslate('Loading results…')).addClass('loading');
-    $.get(`${urlBrowse}?${queries.join('&')}`).done(function(html) {
-        sectionContent.html(html).removeClass('loading');
-        setPermalinkFragment();
-    }).fail(failBrowse);
-});
-
-// Then, set up the page for first load.
-if (FacetedBrowse.getState('categoryId')) {
-    // This page has a previously saved category state.
-    $.get(urlFacets, {category_id: FacetedBrowse.getState('categoryId')}).done(function(html) {
-        sectionSidebar.html(html);
-        applyPreviousState();
-    }).fail(failFacet);
-} else if (container.data('categoryId')) {
-    // There is one category. Skip categories list and show facets list.
-    $.get(urlFacets, {category_id: container.data('categoryId')}).done(function(html) {
-        sectionSidebar.html(html);
-        applyPreviousState();
-        $('#categories-return').hide();
-    }).fail(failFacet);
-} else {
-    // There is more than one category. Show category list.
-    renderCategories();
-}
-
-// Handle category click.
-container.on('click', '.category', function(e) {
-    e.preventDefault();
-    const thisCategory = $(this);
-    FacetedBrowse.resetState(thisCategory.data('categoryId'));
-    $.get(urlFacets, {category_id: thisCategory.data('categoryId')}).done(function(html) {
-        sectionSidebar.html(html);
-        sectionSidebar.find('.select-list').each(function() {
-            // Must update the select lists so they are truncated.
-            FacetedBrowse.updateSelectList($(this));
-        });
+    // Then, set the state change handler.
+    FacetedBrowse.setStateChangeHandler(function (facetsQuery, sortBy, sortOrder, page) {
+        const facets = $('#facets');
         const queries = [];
-        queries.push(`faceted_browse_category_id=${thisCategory.data('categoryId')}`);
-        $.get(`${urlBrowse}?${queries.join('&')}`).done(function(html) {
-            sectionContent.html(html);
+
+        // Add facets, sorting, and pagination queries.
+        queries.push(facetsQuery);
+        if (null !== sortBy) queries.push(`sort_by=${sortBy}`);
+        if (null !== sortOrder) queries.push(`sort_order=${sortOrder}`);
+        if (null !== page) queries.push(`page=${page}`);
+        queries.push(`faceted_browse_category_id=${facets.data('categoryId')}`);
+        sectionContent.text(Omeka.jsTranslate('Loading results…')).addClass('loading');
+        $.get(`${urlBrowse}?${queries.join('&')}`).done(function (html) {
+            sectionContent.html(html).removeClass('loading');
             setPermalinkFragment();
         }).fail(failBrowse);
-    }).fail(failFacet);
-});
-
-// Handle a categories return click.
-container.on('click', '#categories-return', function(e) {
-    e.preventDefault();
-    FacetedBrowse.resetState();
-    renderCategories();
-});
-
-// Handle pagination next button.
-container.on('click', '.next', function(e) {
-    e.preventDefault();
-    const thisButton = $(this);
-    const form = thisButton.prevAll('form');
-    if (!thisButton.hasClass('inactive')) {
-        FacetedBrowse.setPaginationState(parseInt(form.find('input[name="page"]').val()) + 1);
-        $.get(thisButton.prop('href'), function(html) {
-            sectionContent.html(html);
-        });
-    }
-});
-
-// Handle pagination previous button.
-container.on('click', '.previous', function(e) {
-    e.preventDefault();
-    const thisButton = $(this);
-    const form = thisButton.prevAll('form');
-    if (!thisButton.hasClass('inactive')) {
-        FacetedBrowse.setPaginationState(parseInt(form.find('input[name="page"]').val()) - 1);
-        $.get(thisButton.prop('href'), function(html) {
-            sectionContent.html(html);
-        });
-    }
-});
-
-// Handle pagination form.
-container.on('submit', '.pagination form', function(e) {
-    e.preventDefault();
-    const thisForm = $(this);
-    FacetedBrowse.setPaginationState(thisForm.find('input[name="page"]').val());
-    $.get(`${urlBrowse}?${$(this).serialize()}`, {}, function(html) {
-        sectionContent.html(html);
-        setPermalinkFragment();
     });
-});
 
-// Handle sort form.
-container.on('submit', 'form.sorting', function(e) {
-    e.preventDefault();
-    const thisForm = $(this);
-    FacetedBrowse.setSortingState(
-        thisForm.find('select[name="sort_by"]').val(),
-        thisForm.find('select[name="sort_order"]').val()
-    );
-    $.get(`${urlBrowse}?${$(this).serialize()}`, {}, function(html) {
-        sectionContent.html(html);
-        setPermalinkFragment();
-    });
-});
-
-// Handle permalink button (copy to clipboard button).
-container.on('click', '.permalink', function(e) {
-    e.preventDefault();
-    const thisButton = $(this);
-    const permalink = `${thisButton.data('url')}#${thisButton.data('fragment')}`;
-
-    if (navigator.clipboard && window.isSecureContext) {
-        // Use the browser's clipboard API if possible.
-        navigator.clipboard.writeText(permalink).then(function() {
-            showClipboardCopySuccessful();
-        });
+    // Then, set up the page for first load.
+    if (FacetedBrowse.getState('categoryId')) {
+        // This page has a previously saved category state.
+        $.get(urlFacets, { category_id: FacetedBrowse.getState('categoryId') }).done(function (html) {
+            sectionSidebar.html(html);
+            applyPreviousState();
+        }).fail(failFacet);
+    } else if (container.data('categoryId')) {
+        // There is one category. Skip categories list and show facets list.
+        $.get(urlFacets, { category_id: container.data('categoryId') }).done(function (html) {
+            sectionSidebar.html(html);
+            applyPreviousState();
+            $('#categories-return').hide();
+        }).fail(failFacet);
     } else {
-        // Fall back on the temporary input / execCommand('copy') hack.
-        const tempInput = $('<input>');
-        $('body').append(tempInput);
-        tempInput.val(permalink).select();
-        document.execCommand('copy');
-        tempInput.remove();
-        showClipboardCopySuccessful();
+        // There is more than one category. Show category list.
+        renderCategories();
     }
-});
 
-enableModal();
-mediaQuery.addListener(handleTabletChange);
-handleTabletChange(mediaQuery);
+    // Handle category click.
+    container.on('click', '.category', function (e) {
+        e.preventDefault();
+        const thisCategory = $(this);
+        FacetedBrowse.resetState(thisCategory.data('categoryId'));
+        $.get(urlFacets, { category_id: thisCategory.data('categoryId') }).done(function (html) {
+            sectionSidebar.html(html);
+            sectionSidebar.find('.select-list').each(function () {
+                // Must update the select lists so they are truncated.
+                FacetedBrowse.updateSelectList($(this));
+            });
+            $('.facets-container').find('a,input,button,select').first().focus();
+            const queries = [];
+            queries.push(`faceted_browse_category_id=${thisCategory.data('categoryId')}`);
+            $.get(`${urlBrowse}?${queries.join('&')}`).done(function (html) {
+                sectionContent.html(html);
+                setPermalinkFragment();
+            }).fail(failBrowse);
+        }).fail(failFacet);
+    });
+
+    // Handle a categories return click.
+    container.on('click', '#categories-return', function (e) {
+        FacetedBrowse.resetState();
+        renderCategories();
+    });
+
+    // Handle pagination next button.
+    container.on('click', '.next', function (e) {
+        e.preventDefault();
+        const thisButton = $(this);
+        const form = thisButton.prevAll('form');
+        if (!thisButton.hasClass('inactive')) {
+            FacetedBrowse.setPaginationState(parseInt(form.find('input[name="page"]').val()) + 1);
+            $.get(thisButton.prop('href'), function (html) {
+                sectionContent.html(html);
+            });
+        }
+    });
+
+    // Handle pagination previous button.
+    container.on('click', '.previous', function (e) {
+        e.preventDefault();
+        const thisButton = $(this);
+        const form = thisButton.prevAll('form');
+        if (!thisButton.hasClass('inactive')) {
+            FacetedBrowse.setPaginationState(parseInt(form.find('input[name="page"]').val()) - 1);
+            $.get(thisButton.prop('href'), function (html) {
+                sectionContent.html(html);
+            });
+        }
+    });
+
+    // Handle pagination form.
+    container.on('submit', '.pagination form', function (e) {
+        e.preventDefault();
+        const thisForm = $(this);
+        FacetedBrowse.setPaginationState(thisForm.find('input[name="page"]').val());
+        $.get(`${urlBrowse}?${$(this).serialize()}`, {}, function (html) {
+            sectionContent.html(html);
+            setPermalinkFragment();
+        });
+    });
+
+    // Handle sort form.
+    container.on('submit', 'form.sorting', function (e) {
+        e.preventDefault();
+        const thisForm = $(this);
+        FacetedBrowse.setSortingState(
+            thisForm.find('select[name="sort_by"]').val(),
+            thisForm.find('select[name="sort_order"]').val()
+        );
+        $.get(`${urlBrowse}?${$(this).serialize()}`, {}, function (html) {
+            sectionContent.html(html);
+            setPermalinkFragment();
+        });
+    });
+
+    // Handle permalink button (copy to clipboard button).
+    container.on('click', '.permalink', function (e) {
+        e.preventDefault();
+        const thisButton = $(this);
+        const permalink = `${thisButton.data('url')}#${thisButton.data('fragment')}`;
+
+        if (navigator.clipboard && window.isSecureContext) {
+            // Use the browser's clipboard API if possible.
+            navigator.clipboard.writeText(permalink).then(function () {
+                showClipboardCopySuccessful();
+            });
+        } else {
+            // Fall back on the temporary input / execCommand('copy') hack.
+            const tempInput = $('<input>');
+            $('body').append(tempInput);
+            tempInput.val(permalink).select();
+            document.execCommand('copy');
+            tempInput.remove();
+            showClipboardCopySuccessful();
+        }
+    });
+
+    enableModal();
+    mediaQuery.addListener(handleTabletChange);
+    handleTabletChange(mediaQuery);
 
 });

--- a/asset/js/site/page.js
+++ b/asset/js/site/page.js
@@ -17,16 +17,16 @@ $(document).ready(function () {
     const failCategory = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching category markup.')} ${data.status} (${data.statusText})`);
 
     // Set breakpoint for using facet modal window.
-    const mediaQuery = window.matchMedia('(min-width: 896px)');
+    const mediaQuery = window.matchMedia('(max-width: 39.9988em)');
 
     // Reset modal attributes for desktop widths.
     const handleTabletChange = function (e) {
         if (e.matches) {
-            closeModal();
-            sectionSidebar.unwrap();
-        } else {
             const dialogWrapper = $('<dialog id="section-sidebar-dialog" aria-label="Mobile dialog" aria-labelledby="section-sidebar-dialog section-sidebar"></dialog>');
             sectionSidebar.wrap(dialogWrapper);
+        } else if (document.getElementById('section-sidebar-dialog')) {
+            closeModal();
+            sectionSidebar.unwrap();
         }
     };
 
@@ -44,7 +44,10 @@ $(document).ready(function () {
     };
 
     const closeModal = function () {
-        document.getElementById('section-sidebar-dialog').close();
+        const activeModal = document.getElementById('section-sidebar-dialog');
+        if (activeModal) {
+            activeModal.close();
+        }
         modalToggleButton.attr('aria-expanded', 'false');
     }
 

--- a/asset/js/site/page.js
+++ b/asset/js/site/page.js
@@ -21,49 +21,31 @@ const mediaQuery = window.matchMedia('(min-width: 896px)');
 
 // Reset modal attributes for desktop widths.
 const handleTabletChange = function(e) {
-    modalToggleButton.attr('aria-expanded', 'false');
-    sectionContent.attr('aria-hidden', 'true');
     if (e.matches) {
-        sectionSidebar.attr('aria-hidden', 'false');
-        modalToggleButton.attr('aria-expanded', 'false');
-        sectionContent.attr('aria-hidden', 'false');
+        closeModal();
+        sectionSidebar.unwrap();
+    } else {
+        const dialogWrapper = $('<dialog id="section-sidebar-dialog" aria-label="Mobile dialog" aria-labelledby="section-sidebar-dialog section-sidebar"></dialog>');
+        sectionSidebar.wrap(dialogWrapper);
     }
 };
 
 // Implements modal behavior for facet sidebar on mobile widths.
 const enableModal = function() {
-    var lastFocus;
-
     container.on('click', '#section-sidebar-modal-toggle', function() {
-        sectionSidebar.toggleClass('open');
-        if (modalToggleButton.attr('aria-expanded') == 'true') {
-            modalToggleButton.attr('aria-expanded', 'false');
-            sectionSidebar.attr('aria-hidden', 'true');
-            sectionContent.attr('aria-hidden', 'false');
-        } else {
-            modalToggleButton.attr('aria-expanded', 'true');
-            sectionSidebar.attr('aria-hidden', 'false');
-            sectionContent.attr('aria-hidden', 'true');
-        }
-        sectionSidebar.trigger('toggle');
+        modalToggleButton.attr('aria-expanded', 'false');
+        document.getElementById('section-sidebar-dialog').showModal();
     });
 
-    sectionSidebar.on('click', '.close-button', function() {
-        lastFocus.trigger('click').trigger('focus');
-    });
-
-    container.on('toggle', '#section-sidebar', function() {
-        if (sectionSidebar.attr('aria-hidden') == 'false') {
-            sectionSidebar.attr('aria-hidden', 'true');
-            modalCloseButton.trigger('focus');
-            lastFocus = modalToggleButton;
-        } else {
-            sectionSidebar.attr('aria-hidden', 'false');
-            lastFocus.trigger('focus');
-            lastFocus = modalCloseButton;
-        }
+    container.on('click', '#section-sidebar .close-button', function() {
+        closeModal();
     });
 };
+
+const closeModal = function() {
+    document.getElementById('section-sidebar-dialog').close();
+    modalToggleButton.attr('aria-expanded', 'false');
+}
 
 // Show that a copy to clipboard was successful.
 const showClipboardCopySuccessful = () => {
@@ -250,7 +232,7 @@ container.on('click', '.permalink', function(e) {
     }
 });
 
-enableModal('#section-content', '#section-sidebar', '#section-sidebar-modal-toggle');
+enableModal();
 mediaQuery.addListener(handleTabletChange);
 handleTabletChange(mediaQuery);
 

--- a/asset/js/site/page.js
+++ b/asset/js/site/page.js
@@ -1,248 +1,248 @@
 $(document).ready(function () {
 
-    const container = $('#container');
-    const sectionSidebar = $('#section-sidebar');
-    const sectionContent = $('#section-content');
+const container = $('#container');
+const sectionSidebar = $('#section-sidebar');
+const sectionContent = $('#section-content');
 
-    const urlCategories = container.data('urlCategories');
-    const urlFacets = container.data('urlFacets');
-    const urlBrowse = container.data('urlBrowse');
+const urlCategories = container.data('urlCategories');
+const urlFacets = container.data('urlFacets');
+const urlBrowse = container.data('urlBrowse');
 
-    const modalToggleButton = $("#section-sidebar-modal-toggle");
-    const modalCloseButton = $('#section-sidebar-modal-close');
+const modalToggleButton = $("#section-sidebar-modal-toggle");
+const modalCloseButton = $('#section-sidebar-modal-close');
 
-    // Callbacks that handle  request errors.
-    const failBrowse = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching browse markup.')} ${data.status} (${data.statusText})`);
-    const failFacet = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching facet markup.')} ${data.status} (${data.statusText})`);
-    const failCategory = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching category markup.')} ${data.status} (${data.statusText})`);
+// Callbacks that handle  request errors.
+const failBrowse = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching browse markup.')} ${data.status} (${data.statusText})`);
+const failFacet = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching facet markup.')} ${data.status} (${data.statusText})`);
+const failCategory = data => sectionContent.html(`${Omeka.jsTranslate('Error fetching category markup.')} ${data.status} (${data.statusText})`);
 
-    // Set breakpoint for using facet modal window.
-    const mediaQuery = window.matchMedia('(max-width: 39.9988em)');
+// Set breakpoint for using facet modal window.
+const mediaQuery = window.matchMedia('(max-width: 39.9988em)');
 
-    // Reset modal attributes for desktop widths.
-    const handleTabletChange = function (e) {
-        if (e.matches) {
-            const dialogWrapper = $('<dialog id="section-sidebar-dialog" aria-label="Mobile dialog" aria-labelledby="section-sidebar-dialog section-sidebar"></dialog>');
-            sectionSidebar.wrap(dialogWrapper);
-        } else if (document.getElementById('section-sidebar-dialog')) {
-            closeModal();
-            sectionSidebar.unwrap();
-        }
-    };
-
-    // Implements modal behavior for facet sidebar on mobile widths.
-    const enableModal = function () {
-        container.on('click', '#section-sidebar-modal-toggle', function () {
-            const activeDialog = document.getElementById('section-sidebar-dialog');
-            modalToggleButton.attr('aria-expanded', 'true');
-            activeDialog.showModal();
-            sectionSidebar.find('button').first().focus();
-            activeDialog.addEventListener('close', function() {
-                modalToggleButton.attr('aria-expanded', 'false').focus()
-            });
-        });
-
-        container.on('click', '#section-sidebar .close-button', function () {
-            closeModal();
-        });
-    };
-
-    const closeModal = function () {
-        const activeModal = document.getElementById('section-sidebar-dialog');
-        if (activeModal) {
-            activeModal.close();
-        }
-        modalToggleButton.attr('aria-expanded', 'false');
+// Reset modal attributes for desktop widths.
+const handleTabletChange = function (e) {
+    if (e.matches) {
+        const dialogWrapper = $('<dialog id="section-sidebar-dialog" aria-label="Mobile dialog" aria-labelledby="section-sidebar-dialog section-sidebar"></dialog>');
+        sectionSidebar.wrap(dialogWrapper);
+    } else if (document.getElementById('section-sidebar-dialog')) {
+        closeModal();
+        sectionSidebar.unwrap();
     }
+};
 
-    // Show that a copy to clipboard was successful.
-    const showClipboardCopySuccessful = () => {
-        // Indicate successful copy here
-        $('.permalink .success').addClass('active').show();
-        $('.permalink .default').addClass('inactive');
-        setTimeout(function () {
-            $('.permalink .success').fadeOut(1000, function () {
-                $(this).removeClass('active');
-                $('.permalink .default').removeClass('inactive');
-            });
-        }, 1500);
-    };
-
-    /**
-     * Apply a previous state to the page.
-     */
-    const applyPreviousState = function () {
-        $('.facet').each(function () {
-            const thisFacet = $(this);
-            FacetedBrowse.handleFacetApplyState(thisFacet.data('facetType'), thisFacet.data('facetId'), this);
+// Implements modal behavior for facet sidebar on mobile widths.
+const enableModal = function () {
+    container.on('click', '#section-sidebar-modal-toggle', function () {
+        const activeDialog = document.getElementById('section-sidebar-dialog');
+        modalToggleButton.attr('aria-expanded', 'true');
+        activeDialog.showModal();
+        sectionSidebar.find('button').first().focus();
+        activeDialog.addEventListener('close', function() {
+            modalToggleButton.attr('aria-expanded', 'false').focus()
         });
-        FacetedBrowse.triggerStateChange();
-    };
+    });
 
-    /**
-     * Set the permalink fragment.
-     */
-    const setPermalinkFragment = function () {
-        const fragment = encodeURIComponent(JSON.stringify(FacetedBrowse.state))
-        $('.permalink').data('fragment', fragment);
-    };
+    container.on('click', '#section-sidebar .close-button', function () {
+        closeModal();
+    });
+};
 
-    /**
-     * Render the categories of this page.
-     */
-    const renderCategories = function () {
-        $.get(urlCategories).done(function (html) {
-            sectionSidebar.html(html);
-            $('.categories-container').find('a,input,button,select').first().focus();
-            $.get(urlBrowse).done(function (html) {
-                sectionContent.html(html);
-                setPermalinkFragment();
-            }).fail(failBrowse);
-        }).fail(failCategory);
-    };
+const closeModal = function () {
+    const activeModal = document.getElementById('section-sidebar-dialog');
+    if (activeModal) {
+        activeModal.close();
+    }
+    modalToggleButton.attr('aria-expanded', 'false');
+}
 
-    // First, initialize the state.
-    FacetedBrowse.initState();
+// Show that a copy to clipboard was successful.
+const showClipboardCopySuccessful = () => {
+    // Indicate successful copy here
+    $('.permalink .success').addClass('active').show();
+    $('.permalink .default').addClass('inactive');
+    setTimeout(function () {
+        $('.permalink .success').fadeOut(1000, function () {
+            $(this).removeClass('active');
+            $('.permalink .default').removeClass('inactive');
+        });
+    }, 1500);
+};
 
-    // Then, set the state change handler.
-    FacetedBrowse.setStateChangeHandler(function (facetsQuery, sortBy, sortOrder, page) {
-        const facets = $('#facets');
-        const queries = [];
+/**
+    * Apply a previous state to the page.
+    */
+const applyPreviousState = function () {
+    $('.facet').each(function () {
+        const thisFacet = $(this);
+        FacetedBrowse.handleFacetApplyState(thisFacet.data('facetType'), thisFacet.data('facetId'), this);
+    });
+    FacetedBrowse.triggerStateChange();
+};
 
-        // Add facets, sorting, and pagination queries.
-        queries.push(facetsQuery);
-        if (null !== sortBy) queries.push(`sort_by=${sortBy}`);
-        if (null !== sortOrder) queries.push(`sort_order=${sortOrder}`);
-        if (null !== page) queries.push(`page=${page}`);
-        queries.push(`faceted_browse_category_id=${facets.data('categoryId')}`);
-        sectionContent.text(Omeka.jsTranslate('Loading results…')).addClass('loading');
-        $.get(`${urlBrowse}?${queries.join('&')}`).done(function (html) {
-            sectionContent.html(html).removeClass('loading');
+/**
+    * Set the permalink fragment.
+    */
+const setPermalinkFragment = function () {
+    const fragment = encodeURIComponent(JSON.stringify(FacetedBrowse.state))
+    $('.permalink').data('fragment', fragment);
+};
+
+/**
+    * Render the categories of this page.
+    */
+const renderCategories = function () {
+    $.get(urlCategories).done(function (html) {
+        sectionSidebar.html(html);
+        $('.categories-container').find('a,input,button,select').first().focus();
+        $.get(urlBrowse).done(function (html) {
+            sectionContent.html(html);
             setPermalinkFragment();
         }).fail(failBrowse);
-    });
+    }).fail(failCategory);
+};
 
-    // Then, set up the page for first load.
-    if (FacetedBrowse.getState('categoryId')) {
-        // This page has a previously saved category state.
-        $.get(urlFacets, { category_id: FacetedBrowse.getState('categoryId') }).done(function (html) {
-            sectionSidebar.html(html);
-            applyPreviousState();
-        }).fail(failFacet);
-    } else if (container.data('categoryId')) {
-        // There is one category. Skip categories list and show facets list.
-        $.get(urlFacets, { category_id: container.data('categoryId') }).done(function (html) {
-            sectionSidebar.html(html);
-            applyPreviousState();
-            $('#categories-return').hide();
-        }).fail(failFacet);
-    } else {
-        // There is more than one category. Show category list.
-        renderCategories();
+// First, initialize the state.
+FacetedBrowse.initState();
+
+// Then, set the state change handler.
+FacetedBrowse.setStateChangeHandler(function (facetsQuery, sortBy, sortOrder, page) {
+    const facets = $('#facets');
+    const queries = [];
+
+    // Add facets, sorting, and pagination queries.
+    queries.push(facetsQuery);
+    if (null !== sortBy) queries.push(`sort_by=${sortBy}`);
+    if (null !== sortOrder) queries.push(`sort_order=${sortOrder}`);
+    if (null !== page) queries.push(`page=${page}`);
+    queries.push(`faceted_browse_category_id=${facets.data('categoryId')}`);
+    sectionContent.text(Omeka.jsTranslate('Loading results…')).addClass('loading');
+    $.get(`${urlBrowse}?${queries.join('&')}`).done(function (html) {
+        sectionContent.html(html).removeClass('loading');
+        setPermalinkFragment();
+    }).fail(failBrowse);
+});
+
+// Then, set up the page for first load.
+if (FacetedBrowse.getState('categoryId')) {
+    // This page has a previously saved category state.
+    $.get(urlFacets, { category_id: FacetedBrowse.getState('categoryId') }).done(function (html) {
+        sectionSidebar.html(html);
+        applyPreviousState();
+    }).fail(failFacet);
+} else if (container.data('categoryId')) {
+    // There is one category. Skip categories list and show facets list.
+    $.get(urlFacets, { category_id: container.data('categoryId') }).done(function (html) {
+        sectionSidebar.html(html);
+        applyPreviousState();
+        $('#categories-return').hide();
+    }).fail(failFacet);
+} else {
+    // There is more than one category. Show category list.
+    renderCategories();
+}
+
+// Handle category click.
+container.on('click', '.category', function (e) {
+    e.preventDefault();
+    const thisCategory = $(this);
+    FacetedBrowse.resetState(thisCategory.data('categoryId'));
+    $.get(urlFacets, { category_id: thisCategory.data('categoryId') }).done(function (html) {
+        sectionSidebar.html(html);
+        sectionSidebar.find('.select-list').each(function () {
+            // Must update the select lists so they are truncated.
+            FacetedBrowse.updateSelectList($(this));
+        });
+        $('.facets-container').find('a,input,button,select').first().focus();
+        const queries = [];
+        queries.push(`faceted_browse_category_id=${thisCategory.data('categoryId')}`);
+        $.get(`${urlBrowse}?${queries.join('&')}`).done(function (html) {
+            sectionContent.html(html);
+            setPermalinkFragment();
+        }).fail(failBrowse);
+    }).fail(failFacet);
+});
+
+// Handle a categories return click.
+container.on('click', '#categories-return', function (e) {
+    FacetedBrowse.resetState();
+    renderCategories();
+});
+
+// Handle pagination next button.
+container.on('click', '.next', function (e) {
+    e.preventDefault();
+    const thisButton = $(this);
+    const form = thisButton.prevAll('form');
+    if (!thisButton.hasClass('inactive')) {
+        FacetedBrowse.setPaginationState(parseInt(form.find('input[name="page"]').val()) + 1);
+        $.get(thisButton.prop('href'), function (html) {
+            sectionContent.html(html);
+        });
     }
+});
 
-    // Handle category click.
-    container.on('click', '.category', function (e) {
-        e.preventDefault();
-        const thisCategory = $(this);
-        FacetedBrowse.resetState(thisCategory.data('categoryId'));
-        $.get(urlFacets, { category_id: thisCategory.data('categoryId') }).done(function (html) {
-            sectionSidebar.html(html);
-            sectionSidebar.find('.select-list').each(function () {
-                // Must update the select lists so they are truncated.
-                FacetedBrowse.updateSelectList($(this));
-            });
-            $('.facets-container').find('a,input,button,select').first().focus();
-            const queries = [];
-            queries.push(`faceted_browse_category_id=${thisCategory.data('categoryId')}`);
-            $.get(`${urlBrowse}?${queries.join('&')}`).done(function (html) {
-                sectionContent.html(html);
-                setPermalinkFragment();
-            }).fail(failBrowse);
-        }).fail(failFacet);
-    });
-
-    // Handle a categories return click.
-    container.on('click', '#categories-return', function (e) {
-        FacetedBrowse.resetState();
-        renderCategories();
-    });
-
-    // Handle pagination next button.
-    container.on('click', '.next', function (e) {
-        e.preventDefault();
-        const thisButton = $(this);
-        const form = thisButton.prevAll('form');
-        if (!thisButton.hasClass('inactive')) {
-            FacetedBrowse.setPaginationState(parseInt(form.find('input[name="page"]').val()) + 1);
-            $.get(thisButton.prop('href'), function (html) {
-                sectionContent.html(html);
-            });
-        }
-    });
-
-    // Handle pagination previous button.
-    container.on('click', '.previous', function (e) {
-        e.preventDefault();
-        const thisButton = $(this);
-        const form = thisButton.prevAll('form');
-        if (!thisButton.hasClass('inactive')) {
-            FacetedBrowse.setPaginationState(parseInt(form.find('input[name="page"]').val()) - 1);
-            $.get(thisButton.prop('href'), function (html) {
-                sectionContent.html(html);
-            });
-        }
-    });
-
-    // Handle pagination form.
-    container.on('submit', '.pagination form', function (e) {
-        e.preventDefault();
-        const thisForm = $(this);
-        FacetedBrowse.setPaginationState(thisForm.find('input[name="page"]').val());
-        $.get(`${urlBrowse}?${$(this).serialize()}`, {}, function (html) {
+// Handle pagination previous button.
+container.on('click', '.previous', function (e) {
+    e.preventDefault();
+    const thisButton = $(this);
+    const form = thisButton.prevAll('form');
+    if (!thisButton.hasClass('inactive')) {
+        FacetedBrowse.setPaginationState(parseInt(form.find('input[name="page"]').val()) - 1);
+        $.get(thisButton.prop('href'), function (html) {
             sectionContent.html(html);
-            setPermalinkFragment();
         });
+    }
+});
+
+// Handle pagination form.
+container.on('submit', '.pagination form', function (e) {
+    e.preventDefault();
+    const thisForm = $(this);
+    FacetedBrowse.setPaginationState(thisForm.find('input[name="page"]').val());
+    $.get(`${urlBrowse}?${$(this).serialize()}`, {}, function (html) {
+        sectionContent.html(html);
+        setPermalinkFragment();
     });
+});
 
-    // Handle sort form.
-    container.on('submit', 'form.sorting', function (e) {
-        e.preventDefault();
-        const thisForm = $(this);
-        FacetedBrowse.setSortingState(
-            thisForm.find('select[name="sort_by"]').val(),
-            thisForm.find('select[name="sort_order"]').val()
-        );
-        $.get(`${urlBrowse}?${$(this).serialize()}`, {}, function (html) {
-            sectionContent.html(html);
-            setPermalinkFragment();
-        });
+// Handle sort form.
+container.on('submit', 'form.sorting', function (e) {
+    e.preventDefault();
+    const thisForm = $(this);
+    FacetedBrowse.setSortingState(
+        thisForm.find('select[name="sort_by"]').val(),
+        thisForm.find('select[name="sort_order"]').val()
+    );
+    $.get(`${urlBrowse}?${$(this).serialize()}`, {}, function (html) {
+        sectionContent.html(html);
+        setPermalinkFragment();
     });
+});
 
-    // Handle permalink button (copy to clipboard button).
-    container.on('click', '.permalink', function (e) {
-        e.preventDefault();
-        const thisButton = $(this);
-        const permalink = `${thisButton.data('url')}#${thisButton.data('fragment')}`;
+// Handle permalink button (copy to clipboard button).
+container.on('click', '.permalink', function (e) {
+    e.preventDefault();
+    const thisButton = $(this);
+    const permalink = `${thisButton.data('url')}#${thisButton.data('fragment')}`;
 
-        if (navigator.clipboard && window.isSecureContext) {
-            // Use the browser's clipboard API if possible.
-            navigator.clipboard.writeText(permalink).then(function () {
-                showClipboardCopySuccessful();
-            });
-        } else {
-            // Fall back on the temporary input / execCommand('copy') hack.
-            const tempInput = $('<input>');
-            $('body').append(tempInput);
-            tempInput.val(permalink).select();
-            document.execCommand('copy');
-            tempInput.remove();
+    if (navigator.clipboard && window.isSecureContext) {
+        // Use the browser's clipboard API if possible.
+        navigator.clipboard.writeText(permalink).then(function () {
             showClipboardCopySuccessful();
-        }
-    });
+        });
+    } else {
+        // Fall back on the temporary input / execCommand('copy') hack.
+        const tempInput = $('<input>');
+        $('body').append(tempInput);
+        tempInput.val(permalink).select();
+        document.execCommand('copy');
+        tempInput.remove();
+        showClipboardCopySuccessful();
+    }
+});
 
-    enableModal();
-    mediaQuery.addListener(handleTabletChange);
-    handleTabletChange(mediaQuery);
+enableModal();
+mediaQuery.addListener(handleTabletChange);
+handleTabletChange(mediaQuery);
 
 });

--- a/asset/js/site/page.js
+++ b/asset/js/site/page.js
@@ -33,9 +33,13 @@ $(document).ready(function () {
     // Implements modal behavior for facet sidebar on mobile widths.
     const enableModal = function () {
         container.on('click', '#section-sidebar-modal-toggle', function () {
-            modalToggleButton.attr('aria-expanded', 'false');
-            document.getElementById('section-sidebar-dialog').showModal();
+            const activeDialog = document.getElementById('section-sidebar-dialog');
+            modalToggleButton.attr('aria-expanded', 'true');
+            activeDialog.showModal();
             sectionSidebar.find('button').first().focus();
+            activeDialog.addEventListener('close', function() {
+                modalToggleButton.attr('aria-expanded', 'false').focus()
+            });
         });
 
         container.on('click', '#section-sidebar .close-button', function () {

--- a/view/faceted-browse/site/page/categories.phtml
+++ b/view/faceted-browse/site/page/categories.phtml
@@ -1,9 +1,6 @@
 <button id="section-sidebar-modal-close" class="close-button" aria-label="<?php echo $this->escapeHtml($this->translate('Close')); ?>" aria-labelledby="section-sidebar-modal-close section-sidebar" type="button">
   <span aria-hidden="true" class="close-glyph"></span>
 </button>
-<div class="sr-only" id="facet-modal-description">
-    This is a dialog window which overlays the main content of the page. The modal begins with a fieldset called 'Browse'. Pressing the Close Modal button at the top right of the modal will close the modal and bring you back to where you were on the page.
-</div>
 <?php $categories = $page->categories(); ?>
 <fieldset class="categories-container">
     <legend><?php echo $this->translate('Browse'); ?></legend>

--- a/view/faceted-browse/site/page/facets.phtml
+++ b/view/faceted-browse/site/page/facets.phtml
@@ -1,11 +1,7 @@
 <button id="section-sidebar-modal-close" class="close-button" aria-label="<?php echo $this->escapeHtml($this->translate('Close')); ?>" aria-labelledby="section-sidebar-modal-close section-sidebar" type="button">
   <span aria-hidden="true" class="close-glyph"></span>
 </button>
-<div class="sr-only" id="facet-modal-description">
-    This is a dialog window which overlays the main content of the page. The modal begins with a fieldset called <?php echo $category->name(); ?>. Pressing the Close Modal button at the top right of the modal will close the modal and bring you back to where you were on the page.
-</div>
-<?php echo $this->hyperlink($this->translate('Back'), [], ['id' => 'categories-return', 'class' => 'button']); ?>
-<fieldset class="facets-container">
+<fieldset class="facets-container" aria-label="<?php echo $category->name(); ?>">
     <legend><?php echo $category->name(); ?></legend>
     <?php
     $categoryOptions = [
@@ -36,4 +32,5 @@
         <?php endif; ?>
         <?php endforeach; ?>
     </div>
+    <button id="categories-return" class="button"><?php echo $this->translate('Back'); ?></button>
 </fieldset>

--- a/view/faceted-browse/site/page/page.phtml
+++ b/view/faceted-browse/site/page/page.phtml
@@ -21,7 +21,7 @@ if (1 === count($categories)) {
     data-url-facets="<?php echo $this->escapeHtml($this->url(null, ['action' => 'facets'], true)); ?>"
     data-url-browse="<?php echo $this->escapeHtml($this->url(null, ['action' => 'browse'], true)); ?>"
     data-category-id="<?php echo $this->escapeHtml($categoryId); ?>">
-    <button id="section-sidebar-modal-toggle" type="button"><?php echo $this->translate('Filters'); ?></button>
+    <button id="section-sidebar-modal-toggle" type="button" class="button"><?php echo $this->translate('Filters'); ?></button>
     <div id="section-sidebar" class="mobile modal-panel" aria-describedby="facet-modal-description" aria-label="<?php echo $this->translate('Filters'); ?>"></div>
     <div id="section-content"></div>
 </div>


### PR DESCRIPTION
This revises the current mobile approach by wrapping the facet sidebar with a `<dialog>` element at the mobile breakpoint. This avoids a lot of the issues that were occurring in trying to manage `aria-hidden` attributes in the interest of being screen-reader friendly, and provides more straightforward focus trapping for keyboard navigation.